### PR TITLE
Updated scripts as per phusion/baseimage documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@ CMD ["/sbin/my_init"]
 RUN apt-get update \
     && apt-get -y install unzip libcurl4 curl nano \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && useradd -ms /bin/bash bedrock \
+    && mkdir /etc/service/bedrock
 
-RUN useradd -ms /bin/bash bedrock
+COPY run.sh /etc/service/bedrock/run
+RUN chmod +x /etc/service/bedrock/run
 
 WORKDIR /home/bedrock
 
@@ -26,12 +29,7 @@ RUN chmod +x startup.sh \
     && mkdir -p bedrock_server/config \
     && chown -R bedrock:bedrock .
 
-# If you enable the USER below, there will be permission issues with shared volumes
-USER bedrock
-
 # create volumes for settings that need to be persisted.
 VOLUME /home/bedrock/bedrock_server/worlds /home/bedrock/bedrock_server/config
 
 EXPOSE 19132/udp 19133/udp
-
-ENTRYPOINT /home/bedrock/startup.sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This docker image downloads and runs the Bedrock Dedicated Server at runtime.
 
 ### Update for newer Bedrock Server version
 
-When Mojang update the Bedrock Dedicated Server to a new version (current version 1.9.0) update the `docker-compose.yml` file to point to the new URI and change the tag number in the image node to reflect the new version.
+When Mojang update the Bedrock Dedicated Server to a new version (current version 1.11.4) update the `docker-compose.yml` file to point to the new URI and change the tag number in the image node to reflect the new version.
 
 ### Modify server settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   bedrock_server:
-    image: bedrock_server:1.9.0
+    image: bedrock_server:1.11.4
     build: .
     container_name: bedrock_server
     ports: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,3 @@ services:
       # mounting this volume in Windows at least the bedrock server crashes.
       - ./data/worlds:/home/bedrock/bedrock_server/import/worlds
       - ./data/config:/home/bedrock/bedrock_server/config
-      
-    # override the default entrypoint to include access to a bash terminal for debugging.
-    entrypoint: bash -c "/home/bedrock/startup.sh && /bin/bash"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# we execute the startup script as the 'bedrock' user.
+exec /sbin/setuser bedrock /home/bedrock/startup.sh

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Update this as the file changes.  Please be sure to agree to the EULA
-BEDROCK_DOWNLOAD_ZIP=https://minecraft.azureedge.net/bin-linux/bedrock-server-1.9.0.15.zip
+BEDROCK_DOWNLOAD_ZIP=https://minecraft.azureedge.net/bin-linux/bedrock-server-1.11.4.2.zip
 ZIPFILE=$(basename $BEDROCK_DOWNLOAD_ZIP)
 
 cd /home/bedrock/bedrock_server

--- a/startup.sh
+++ b/startup.sh
@@ -7,7 +7,7 @@ ZIPFILE=$(basename $BEDROCK_DOWNLOAD_ZIP)
 cd /home/bedrock/bedrock_server
 
 if [ ! -f $ZIPFILE ]; then
-   echo "Downloading file"
+   echo "Downloading Bedrock Server code"
 
    # Download and if successful, unzip (don't allow overwrites)
    curl --fail -O $BEDROCK_DOWNLOAD_ZIP && unzip -n -q $ZIPFILE
@@ -28,8 +28,11 @@ function copy_config() {
       cp $filename.defaults $filename
       cp $filename.defaults config/$filename
    fi
+
+   # TODO we need to adjust the copied file permissions as required.
 }
 
+echo "Copying config and world data"
 copy_config server.properties
 copy_config ops.json
 copy_config whitelist.json
@@ -47,5 +50,5 @@ else
    echo "Server software not downloaded or unpacked!"
 fi
 
-# let's copy the resulting world data back out
+echo "Copying world data back out"
 cp -r -u worlds/* import/worlds/


### PR DESCRIPTION
Using the [documentation](https://github.com/phusion/baseimage-docker#adding_additional_daemons) for the base Docker image, I have updated the startup scripts to work with the existing scripts.  There is just one further issue relating to copying the world data back to the original volume mounts.

Closes #3 